### PR TITLE
Handle IndexError exceptions on queries (resolves #8)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # gglsbl-rest
 
+## v1.3.1 (2017-10-28)
+- Revert to gglsbl 1.4.5 to avoid exceptions on queries as per https://github.com/afilipovich/gglsbl/issues/28;
+- Delete SafeBrowsingList object after database update to ensure sqlite connection is closed before moving the database file.
+
 ## v1.3.0 (2017-10-26)
 - Added environment variable KEEPALIVE to control persistent connection idle period;
 - Added environment variable LIMIT_REQUEST_LINE to increase the default gunicorn maximum HTTP request line size, since we embed full URLs into our URI.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 flask==0.12.2
-gglsbl==1.4.6
+gglsbl==1.4.5
 pid==2.1.1
 gunicorn==19.7.1

--- a/update.py
+++ b/update.py
@@ -44,6 +44,7 @@ def update_hash_prefix_cache():
         logger.info('downloading database to ' + tmp_file)
         sbl = SafeBrowsingList(gsb_api_key, tmp_file, True)
         sbl.update_hash_prefix_cache()
+        del sbl
         logger.info("finished creating " + tmp_file)
 
         # rename to inactive file name


### PR DESCRIPTION
- Revert to gglsbl 1.4.5 to avoid exceptions on queries as per https://github.com/afilipovich/gglsbl/issues/28;

- Delete SafeBrowsingList object after database update to ensure sqlite connection is closed before moving the database file.