### PR TITLE
Run as non-root user (resolves #6)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,32 @@
 FROM python:2.7-alpine3.6
 
-## Create app directory
-RUN mkdir -p /root/gglsbl-rest/db
-WORKDIR /root/gglsbl-rest
-ENV GSB_DB_DIR /root/gglsbl-rest/db
-ENV LOGGING_CONFIG /root/gglsbl-rest/logging.conf
-
-## Copy app files and initial GSB database
-COPY ["requirements.txt", "*.py", "logging.conf", "./"]
-
 # Install necessary OS and Python packages
 RUN apk update && \
     apk upgrade && \
-    pip install -r requirements.txt && \
+    apk add su-exec && \
+    adduser -D -s /sbin/nologin gglsbl
+
+## Populate app directory
+WORKDIR /home/gglsbl
+ENV GSB_DB_DIR /home/gglsbl/db
+COPY ["requirements.txt", "*.py", "logging.conf", "./"]
+ENV LOGGING_CONFIG /home/gglsbl/logging.conf
+
+RUN pip install -r requirements.txt && \
     rm -rf /root/.cache/pip/* && \
     rm -rf /var/cache/apk/* && \
     rm -rf /tmp/* && \
     rm -rf /root/.cache/ && \
-    crontab -l | { cat; echo "*/30   *   *   *   *   /usr/local/bin/python /root/gglsbl-rest/update.py"; } | crontab -
+    mkdir -p $GSB_DB_DIR && \
+    chown -R gglsbl:gglsbl * && \
+    crontab -l | { cat; echo "*/5   *   *   *   *   /sbin/su-exec gglsbl:gglsbl /usr/local/bin/python /home/gglsbl/update.py"; } | crontab -
 
 EXPOSE 5000
 
 # Perform initial DB update, start crond for regular updates then start app.
-ENTRYPOINT python update.py && crond -L /proc/1/fd/2 && gunicorn --config config.py --log-config ${LOGGING_CONFIG} app:app
+ENTRYPOINT  chmod 777 /proc/1/fd && \
+            chmod 777 /proc/1/fd/1 && \
+            chmod 777 /proc/1/fd/2 && \
+            su --group=gglsbl gglsbl python update.py && \
+            crond -L /proc/1/fd/2 && \
+            /sbin/su-exec gglsbl:gglsbl gunicorn --config config.py --log-config ${LOGGING_CONFIG} app:app

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 # gglsbl-rest
 
+## v1.5.0 (2017-11-03)
+- Run update.py and main gunicorn process as a regular `gglsbl` user instead of root for added security. 
+
 ## v1.4.0 (2017-10-30)
 - Use a single database in sqlite WAL mode (#10);
 - Default value of WORKERS is now 8 per detected CPU core plus one.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This will cause the service to listen on port 5000 of the host machine. Please r
 
 You can run `docker logs --follow <container name/ID>` to tail the output and determine when the gunicorn workers start, if necessary.
 
-In production, you might want to mount `/root/gglsbl-rest/db` in a [tmpfs RAM disk](https://docs.docker.com/engine/admin/volumes/tmpfs/) for improved performance. Recommended size is 4+ gigabytes, which is roughly twice of a freshly initialized database, but YMMV.
+In production, you might want to mount `/home/gglsbl/db` in a [tmpfs RAM disk](https://docs.docker.com/engine/admin/volumes/tmpfs/) for improved performance. Recommended size is 4+ gigabytes, which is roughly twice of a freshly initialized database, but YMMV.
 
 ## Querying the REST Service
 

--- a/logging.conf
+++ b/logging.conf
@@ -30,14 +30,14 @@ propagate=0
 qualname=gunicorn.access
 
 [handler_console]
-class=FileHandler
+class=StreamHandler
 formatter=generic
-args=('/proc/1/fd/2', )
+args=(sys.stdout, )
 
 [handler_console_access]
-class=FileHandler
+class=StreamHandler
 formatter=access
-args=('/proc/1/fd/1', )
+args=(sys.stdout, )
 
 [formatter_generic]
 format=%(asctime)s pid=%(process)d %(module)s %(levelname)s %(message)s


### PR DESCRIPTION
User `su` and `su-exec` to ensure that both background DB updates and main gunicorn processes as executed not as `root` but as a regular `gglsbl` user.