### PR TITLE
Added HTTPS_PROXY environment variable to README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ The configuration of the REST service can be done using the following environmen
 
 * `MAX_RETRIES` controls how many times the service should retry performing the request if an error occurs. Defaults to 3.
 
+* `HTTPS_PROXY` sets the proxy URL if the service is running behind a proxy. Not set by default. (HTTP_PROXY is not necessary as gglsbl-rest only queries HTTPS URLs)
+
 ## Running
 
 You can run the latest automated build from [Docker Hub](https://hub.docker.com/r/mlsecproject/gglsbl-rest/) as follows:


### PR DESCRIPTION
In corporate environments your services are usually running behind a proxy. So to update the DB and to query the Google API it is necessary to set a proxy for the outgoing queries.

It took me a while to figure out how configure a proxy in gglsbl-rest although the answer is pretty simple and does not even require code changes. Thus, I think it is beneficial to document how to set a proxy.

Thank you for the great tool, works like a charm.