### PR TITLE
Update to Alpine 3.7 (resolves #15)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM python:2.7-alpine3.6
+FROM alpine:3.7
 
 # Install necessary OS packages and create non-root user for service
 RUN apk update && \
     apk upgrade && \
-    apk add su-exec && \
+    apk add -u python py2-pip su-exec && \
     adduser -D -s /sbin/nologin gglsbl
 
 ## Populate app directory
@@ -13,7 +13,8 @@ COPY ["requirements.txt", "*.py", "logging.conf", "./"]
 ENV LOGGING_CONFIG /home/gglsbl/logging.conf
 
 # Install Python packages, cleanup, set permissions and configure crontab
-RUN pip install -r requirements.txt && \
+RUN pip install --upgrade setuptools && \
+    pip install -r requirements.txt && \
     rm -rf /root/.cache/pip/* && \
     rm -rf /var/cache/apk/* && \
     rm -rf /tmp/* && \

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 # gglsbl-rest
 
+## v1.5.1 (2017-12-14)
+- Use alpine:3.7 as base image directly for latest package and OS updates.
+
 ## v1.5.0 (2017-11-03)
 - Run update.py and main gunicorn process as a regular `gglsbl` user instead of root for added security. 
 


### PR DESCRIPTION
Use `alpine:3.7` as base image directly for latest package and OS updates.