### PR TITLE
Alpine and depdency updates (closes #18)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,11 @@
 # gglsbl-rest
 
+## v1.5.2 (2018-12-21)
+- Use alpine:3.8 as base image directly for latest package and OS updates;
+- Update dependencies: gglsbl 1.4.14, and gunicorn 19.9.0;
+- Replace use of crond with apscheduler Python package to run regular updates;
+- Since crond is not longer used, no processes need to run as root and we can use `USER` Dockerfile directive to drop privileges.
+
 ## v1.5.1 (2017-12-14)
 - Use alpine:3.7 as base image directly for latest package and OS updates.
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ This repository implements a Dockerized REST service to look up URLs in Google S
 
 The main challenge with running gglsbl in a REST service is that the process of updating the local sqlite database takes several minutes. Plus, the sqlite database is locked during writes by default, so that would essentially cause very noticeable downtime or a race condition.
 
-So what gglsbl-rest does since version 1.4.0 is to set the sqlite database to [write-ahead logging](https://sqlite.org/wal.html) mode so that readers and writers can work concurrently. A cron job runs every 30 minutes to update the database and then performs a [full checkpoint](https://sqlite.org/pragma.html#pragma_wal_checkpoint) to ensure readers have optimal performance.
+So what gglsbl-rest does since version 1.4.0 is to set the sqlite database to [write-ahead logging](https://sqlite.org/wal.html) mode so that readers and writers can work concurrently. A scheduled task runs every 30 minutes to update the database and then performs a [full checkpoint](https://sqlite.org/pragma.html#pragma_wal_checkpoint) to ensure readers have optimal performance.
 
 Versions before 1.4.0 maintained two sets of files on disk and switched between them, which is why the status endpoint has the output format lists "alternatives". But the current approach has many advantages, as it reuses fresh downloaded data across updates and cached full hash data.
 
-For security reasons, even though `crond` is run as `root`, both the background task of updating the database and the [gunicorn](https://pypi.python.org/pypi/gunicorn) process are executed as a non-root user called `gglsbl`.
+The regular update is executed using [APScheduler](https://pypi.org/project/APScheduler/) on the [gunicorn](https://pypi.python.org/pypi/gunicorn) master process. For security reasons, [gunicorn](https://pypi.python.org/pypi/gunicorn) is executed with a regular user called `gglsbl` using the Dockerfile `USER` directive.
 
 ## Environment Variables
 

--- a/app.py
+++ b/app.py
@@ -1,12 +1,14 @@
+from os import environ, path
+from subprocess import Popen
+
 import logging.config
 import time
-from os import environ, path
-
 from flask import Flask, request, jsonify, abort
 from gglsbl import SafeBrowsingList
-from multiprocessing import cpu_count
+
 
 # basic app configuration and options
+logging.config.fileConfig('logging.conf')
 app = Flask("gglsbl-rest")
 gsb_api_key = environ['GSB_API_KEY']
 dbfile = path.join(environ.get('GSB_DB_DIR', '/tmp'), 'sqlite.db')
@@ -76,7 +78,9 @@ def status_page():
     return jsonify(retval)
 
 
-# run internal Flask server if executed directly
+# run development Flask server if executed directly
 if __name__ == '__main__':
-    logging.config.fileConfig('logging.conf')
-    app.run(processes=int(environ.get('WORKERS', cpu_count() * 2 + 1)))
+    po = Popen("python update.py", shell=True)
+    po.wait()
+    app.env = 'development'
+    app.run(processes=1, host="0.0.0.0", port=5001, debug=True)

--- a/config.py
+++ b/config.py
@@ -1,10 +1,39 @@
-from multiprocessing import cpu_count
 from os import environ
+
+import logging.config
+from apscheduler.schedulers.background import BackgroundScheduler
+from multiprocessing import cpu_count
+from subprocess import Popen
+
+logging.config.fileConfig('logging.conf')
 
 bind = "0.0.0.0:5000"
 workers = int(environ.get('WORKERS', cpu_count() * 8 + 1))
 timeout = int(environ.get('TIMEOUT', 120))
-access_log_format='%(h)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" "%({X-Forwarded-For}i)s" "%({X-Forwarded-Port}i)s" "%({X-Forwarded-Proto}i)s"  "%({X-Amzn-Trace-Id}i)s"'
+access_log_format = '%(h)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" "%({X-Forwarded-For}i)s" "%({X-Forwarded-Port}i)s" "%({X-Forwarded-Proto}i)s"  "%({X-Amzn-Trace-Id}i)s"'
 max_requests = int(environ.get('MAX_REQUESTS', 16384))
 limit_request_line = int(environ.get('LIMIT_REQUEST_LINE', 8190))
 keepalive = int(environ.get('KEEPALIVE', 60))
+
+log = logging.getLogger(__name__)
+
+
+def update():
+    log.info("Starting update process...")
+    po = Popen("python update.py", shell=True)
+    log.info("Update started as PID %d", po.pid)
+    rc = po.wait()
+    log.info("Update process finished with status code %d", rc)
+
+
+def on_starting(server):
+    log.info("Initial database load...")
+    po = Popen("python update.py", shell=True)
+    log.info("Update started as PID %d", po.pid)
+    rc = po.wait()
+    log.info("Update process finished with status code %d", rc)
+
+    log.info("Starting scheduler...")
+    sched = BackgroundScheduler(timezone="UTC")
+    sched.start()
+    sched.add_job(update, id="update", coalesce=True, max_instances=1, trigger='interval', minutes=30)

--- a/logging.conf
+++ b/logging.conf
@@ -1,6 +1,5 @@
 [loggers]
-keys=root, update, gunicorn.error, gunicorn.access
-
+keys=root, update, gunicorn.error, gunicorn.access, flask.app, __config__
 [handlers]
 keys=console, console_access
 
@@ -28,6 +27,18 @@ level=INFO
 handlers=console_access
 propagate=0
 qualname=gunicorn.access
+
+[logger_flask.app]
+level=DEBUG
+handlers=console
+propagate=0
+qualname=flask.app
+
+[logger___config__]
+level=INFO
+handlers=console
+propagate=0
+qualname=__config__
 
 [handler_console]
 class=StreamHandler

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 flask==1.0.2
-gglsbl==1.4.11
+apscheduler==3.5.3
+gglsbl==1.4.14
 pid==2.2.0
-gunicorn==19.8.1
+gunicorn==19.9.0


### PR DESCRIPTION
* Use alpine:3.8 as base image directly for latest package and OS updates;
* Update dependencies: gglsbl 1.4.14, and gunicorn 19.9.0;
* Replace use of crond with apscheduler Python package to run regular updates;
* Since crond is not longer used, no processes need to run as root and we can use USER dockerfile directive to drop privileges.